### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ OR
 $ yarn add nachos-ui
 ```
 
+The ThemeProvider component should be set at the highest level of your app. If it is not, Nachos UI components will NOT render.
+
+```
+import { ThemeProvider } from "nachos-ui";
+
+export default (App = () => (
+  <ThemeProvider>
+    <RestOfYourApp />
+  </ThemeProvider>
+));
+```
+
 ```jsx
 import React from 'react'
 import { View } from 'react-native'


### PR DESCRIPTION
Some components like the Input component fail to render with errors such as:
`Unhandled JS Exception: TypeError: TypeError: TypeError: Cannot read property 'color' of undefined`
if the highest component in the app is not wrapped in a `<ThemeProvider>`